### PR TITLE
chore(deps): graphql 16 -> 17

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@emotion/styled": "11.14.1",
         "@mui/icons-material": "7.3.2",
         "@mui/material": "7.3.2",
-        "graphql": "16.11.0",
+        "graphql": "17.0.1",
         "lodash": "4.18.1",
         "maplibre-gl": "3.6.2",
         "react": "19.2.7",
@@ -3333,18 +3333,18 @@
       }
     },
     "node_modules/graphql": {
-      "version": "16.11.0",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.11.0.tgz",
-      "integrity": "sha512-mS1lbMsxgQj6hge1XZ6p7GPhbrtFwUFYi3wRzXAC/FmYnyXMTvvI3td3rjmQ2u8ewXueaSvRPWaEcgVVOT9Jnw==",
+      "version": "17.0.1",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-17.0.1.tgz",
+      "integrity": "sha512-8eWbg5Zcv/8o20nzEjHUGPTj20MLFJjc5kagbIPxbaeGxvFwpitJhemEC/k17n5+UD4M/9ea5rTuce78mELujQ==",
       "license": "MIT",
       "engines": {
-        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+        "node": "^22.0.0 || ^24.0.0 || ^25.0.0 || >=26.0.0"
       }
     },
     "node_modules/graphql-tag": {
-      "version": "2.12.6",
-      "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.12.6.tgz",
-      "integrity": "sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==",
+      "version": "2.12.7",
+      "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.12.7.tgz",
+      "integrity": "sha512-xnE/NFzy+0eIesvAsREJZ284zTl/wYuBAvpsFSDhRGRdRHdnE90M21Q3xAWyYInb0J756c6x0pIQ62+vtvOs1Q==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.1.0"
@@ -3353,7 +3353,7 @@
         "node": ">=10"
       },
       "peerDependencies": {
-        "graphql": "^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+        "graphql": "^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
     "node_modules/has-flag": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@emotion/styled": "11.14.1",
     "@mui/icons-material": "7.3.2",
     "@mui/material": "7.3.2",
-    "graphql": "16.11.0",
+    "graphql": "17.0.1",
     "lodash": "4.18.1",
     "maplibre-gl": "3.6.2",
     "react": "19.2.7",


### PR DESCRIPTION
Bumps `graphql` 16.11.0 → 17.0.1.

**Why low-risk:** `graphql` is consumed only transitively — the app imports `gql` from `@apollo/client`, not from `graphql` directly (no direct `graphql` imports in `src/`). `@apollo/client@4.2.3` declares `graphql: ^16.0.0 || ^17.0.0` peer support.

**Verification:** `npm audit --audit-level=moderate` ✅ · `npm run lint` ✅ · `tsc && vite build` ✅

**Base:** stacked on #259. Retarget to `master` after #259 merges.